### PR TITLE
fix: `envGOVULNDB` variable name

### DIFF
--- a/internal/govulncheck/config.go
+++ b/internal/govulncheck/config.go
@@ -33,13 +33,13 @@ const (
 )
 
 const (
-	// EnvGOVULNDB is the GOVULNDB environment variable, which accepts a list
+	// envGOVULNDB is the GOVULNDB environment variable, which accepts a list
 	// of a comma-separated list of vulnerability database URLs, with http://,
 	// https://, or file:// protocols.
 	//
 	// If this is empty, govulncheck will default to the Go vulnerability
 	// database at vuln.go.dev.
-	EnvGOVULNDB = "GOVULNDB"
+	envGOVULNDB = "GOVULNDB"
 
 	// envGOVULNDB represents the GOVERSION environment variable.
 	envGOVERSION = "GOVERSION"


### PR DESCRIPTION
Use `envGOVULNDB` everywhere.

Signed-off-by: Noel Georgi <git@frezbo.dev>