### PR TITLE
Un-shadow err variable when reading binary

### DIFF
--- a/cmd/govulncheck/main.go
+++ b/cmd/govulncheck/main.go
@@ -115,7 +115,8 @@ func doGovulncheck(patterns []string, sourceAnalysis bool) error {
 		}
 		res, err = govulncheck.Source(ctx, cfg, pkgs)
 	} else {
-		f, err := os.Open(patterns[0])
+		var f *os.File
+		f, err = os.Open(patterns[0])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The call to `os.Open` was shadowing the `err` variable, so the result of `gvc.Binary` wasn't checked. If something does go wrong, it segfaults in `printText` because `res` is nil.