### PR TITLE
README: fix link to privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ information about the Go vulnerability management system.
 ## Privacy Policy
 
 The privacy policy for `govulncheck` can be found at
-[https://vuln.go.dev/privacy](https://vuln.go.dev/privacy.html).
+[https://vuln.go.dev/privacy](https://vuln.go.dev/privacy).
 
 ## License
 


### PR DESCRIPTION
Closes https://github.com/golang/vuln/pull/5

Basically https://github.com/golang/vuln/pull/5 but trying to complete the CLA dance.