### PR TITLE
Adding ignore file support

### DIFF
--- a/cmd/govulncheck/testdata/usage.ct
+++ b/cmd/govulncheck/testdata/usage.ct
@@ -5,6 +5,8 @@ usage:
 
   -dir string
     	directory to use for loading source files
+  -ignore-file string
+    	ignore vulnerability IDs listed in this file, one ID per line
   -json
     	output JSON
   -tags list
@@ -24,6 +26,8 @@ usage:
 
   -dir string
     	directory to use for loading source files
+  -ignore-file string
+    	ignore vulnerability IDs listed in this file, one ID per line
   -json
     	output JSON
   -tags list

--- a/internal/govulncheck/handler.go
+++ b/internal/govulncheck/handler.go
@@ -13,6 +13,9 @@ type Handler interface {
 	// Vulnerability adds a vulnerability to be printed to the output.
 	Vulnerability(vuln *Vuln) error
 
+	// Ignored adds a vulnerability to be printed as ignored in the output
+	Ignored(vuln *Vuln) error
+
 	// Preamble communicates introductory message to the user.
 	Preamble(preamble *Preamble) error
 

--- a/internal/govulncheck/json.go
+++ b/internal/govulncheck/json.go
@@ -60,6 +60,11 @@ func (o *jsonHandler) Vulnerability(vuln *Vuln) error {
 	return o.enc.Encode(Message{Vulnerability: vuln})
 }
 
+func (o *jsonHandler) Ignored(vuln *Vuln) error {
+	// @TODO using a pointer here so that 'ignored' field gets skipped in the output. Is that good?
+	return o.enc.Encode(Message{Vulnerability: vuln, Ignored: new(bool)})
+}
+
 // Preamble does not do anything in JSON mode.
 func (o *jsonHandler) Preamble(preamble *Preamble) error {
 	return o.enc.Encode(Message{Preamble: preamble})

--- a/internal/govulncheck/result.go
+++ b/internal/govulncheck/result.go
@@ -35,6 +35,7 @@ type Message struct {
 	Preamble      *Preamble `json:"preamble,omitempty"`
 	Progress      string    `json:"progress,omitempty"`
 	Vulnerability *Vuln     `json:"vulnerability,omitempty"`
+	Ignored       *bool     `json:"ignored,omitempty"`
 }
 
 type Preamble struct {

--- a/internal/scan/flags.go
+++ b/internal/scan/flags.go
@@ -18,6 +18,7 @@ type config struct {
 	patterns       []string
 	sourceAnalysis bool
 	db             string
+	ignoreFile     string
 	json           bool
 	dir            string
 	verbose        bool
@@ -35,6 +36,7 @@ func (c *Cmd) parseFlags() (*config, error) {
 	var tagsFlag buildutil.TagsFlag
 	flags := flag.NewFlagSet("", flag.ContinueOnError)
 	flags.BoolVar(&cfg.json, "json", false, "output JSON")
+	flags.StringVar(&cfg.ignoreFile, "ignore-file", "", "ignore vulnerability IDs listed in this file, one ID per line")
 	flags.BoolVar(&cfg.verbose, "v", false, "print a full call stack for each vulnerability")
 	flags.BoolVar(&cfg.test, "test", false, "analyze test files. Only valid for source code.")
 	flags.Var(&tagsFlag, "tags", "comma-separated `list` of build tags")

--- a/internal/scan/text.go
+++ b/internal/scan/text.go
@@ -70,6 +70,14 @@ func (o *textHandler) Vulnerability(vuln *govulncheck.Vuln) error {
 	return nil
 }
 
+func (o *textHandler) Ignored(vuln *govulncheck.Vuln) error {
+	// @TODO Improve formatting? Probably the user should still see more details than just the ID of the vuln?
+	fmt.Fprintln(o.w)
+	fmt.Fprintf(o.w, "Ignoring vulnerability %s", vuln.OSV.ID)
+	fmt.Fprintln(o.w)
+	return nil
+}
+
 // Preamble writes text output formatted according to govulncheck-intro.tmpl.
 func (o *textHandler) Preamble(preamble *govulncheck.Preamble) error {
 	p := *preamble


### PR DESCRIPTION
Hello!

Wanted to check if it would there would be a possibility to add support for a file where users can specify vulnerability IDs that are supposed to be ignored. 

# Use case:

- For example recently we got [`GO-2023-1621`](https://pkg.go.dev/vuln/GO-2023-1621) highlighted "The ScalarMult and ScalarBaseMult methods of the P256 Curve may return an incorrect result if called with some specific unreduced scalars" 
- However, since this only affects very specific use cases, we were quite certain that we won't be affected by this.
- So instead of upgrading right away, we could've added the vulnerability `GO-2023-1621`  to some file in the repo like `.govulnignore`, and then `govulncheck`  would ignore the vulnerability, but still scan for other vulnerabilities.

Aquasec for container scanning supports a `.trivyignore`  file that offers a similar feature (ignoring vulnerabilities), see: https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/

# Implementation

The MR is designed to be a non-breaking change:

- Add a new command line option `-ignore-file` which defaults to empty string
- If the file exists, read it in line by line: Each line is supposed to contain a vulnerability id like `GO-2023-1621` which is supposed to be ignored.
- A lookup set is created from this file 
- The vulnerabilities found by ` govulncheck` are then filtered against this lookup set before getting reported to the user.

Example command line invocation:

```
$ ../govulncheck/govulncheck -ignore-file=.govulnignore ./...         <<<<< This is the NEW option
govulncheck is an experimental tool. Share feedback at https://go.dev/s/govulncheck-feedback.

Using go1.20.1 and govulncheck@v0.0.0-5c89caadefca-20230327072231 with
vulnerability data from https://vuln.go.dev (last modified 2023-03-21 23:29:51 +0000 UTC).

Scanning your code and 107 packages across 1 dependent module for known vulnerabilities...

Ignoring vulnerability GO-2023-1621       <<<<< Shows the vuln as ignored
No vulnerabilities found.

$ cat .govulnignore
GO-2023-1621         <<<<< This is how the file looks like, one vuln ID per line
``` 

# Open tasks

- Do we want to make the file format more complicated (add comments etc.?)
- Using a pointer here so that 'ignored' field gets skipped in the output. Is that good?
- Limitation: Need to resize scanner's capacity for lines over 64K in the ignore file
- Improve output formatting of ignored vulns: Probably the user should still see more details than just the ID of the vuln?
- Add more tests

.... And of course in general, if such a feature would be even accepted (which I don't take for granted but I thought it's worth a try.)

Thank  you in advance for considering this proposal.
