### PR TITLE
feat: support -hide-unused to suprress the ouput of informational section

### DIFF
--- a/internal/scan/flags.go
+++ b/internal/scan/flags.go
@@ -26,6 +26,9 @@ type config struct {
 	test     bool
 	show     []string
 	env      []string
+
+	// hide vulnerabilities associated with the only imported or required modules
+	hideUnused bool
 }
 
 const (
@@ -50,6 +53,7 @@ func parseFlags(cfg *config, stderr io.Writer, args []string) error {
 	flags.Var(&showFlag, "show", "enable display of additional information specified by the comma separated `list`\nThe supported values are 'traces','color', and 'version'")
 	flags.BoolVar(&version, "version", false, "print the version information")
 	scanLevel := flags.String("scan", "symbol", "set the scanning level desired, one of module, package or symbol")
+	flags.BoolVar(&cfg.hideUnused, "hide-unused", false, "ignore unused packages")
 	flags.Usage = func() {
 		fmt.Fprint(flags.Output(), `Govulncheck reports known vulnerabilities in dependencies.
 

--- a/internal/scan/run.go
+++ b/internal/scan/run.go
@@ -63,7 +63,7 @@ func RunGovulncheck(ctx context.Context, env []string, r io.Reader, stdout io.Wr
 	if err != nil {
 		return err
 	}
-	if err := Flush(handler); err != nil {
+	if err := Flush(handler, cfg.hideUnused); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This CL adds an option `-hide-unused`, which will suppress the output of vulnerabilities associated with the only imported or required modules. It helps if we want to focus on the true vulnerabilities. This option only works in text mode rather than JSON mode.

This tries to fix:  https://github.com/golang/go/issues/64970