### PR TITLE
internal/openvex: add initial support for identifying affected product

### DIFF
--- a/internal/openvex/handler.go
+++ b/internal/openvex/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/vuln/internal/govulncheck"
 	"golang.org/x/vuln/internal/osv"
+	"golang.org/x/vuln/internal/semver"
 )
 
 type findingLevel int
@@ -131,7 +132,9 @@ func statements(h *handler) []Statement {
 			},
 			Products: []Product{
 				{
-					ID: DefaultPID,
+					ID: fmt.Sprintf("pkg:golang/%s@%s",
+						osv.Internal.AffectedPath,
+						semver.RemoveSemverPrefix(osv.Internal.AffectedVersion)),
 				},
 			},
 		}

--- a/internal/openvex/vex.go
+++ b/internal/openvex/vex.go
@@ -20,7 +20,6 @@ const (
 	Impact     = "Govulncheck determined that the vulnerable code isn't called"
 
 	DefaultAuthor = "Unknown Author"
-	DefaultPID    = "Unknown Product"
 
 	// The following are defined by the VEX standard.
 	StatusAffected    = "affected"
@@ -102,7 +101,5 @@ type Vulnerability struct {
 
 // Product identifies the products associated with the given vuln.
 type Product struct {
-	// For now, the ID will always be "Unknown product".
-	// This is temporary and is subject to change.
 	ID string `json:"@id,omitempty"`
 }

--- a/internal/osv/osv.go
+++ b/internal/osv/osv.go
@@ -215,6 +215,9 @@ type Entry struct {
 	// DatabaseSpecific contains additional information about the
 	// vulnerability, specific to the Go vulnerability database.
 	DatabaseSpecific *DatabaseSpecific `json:"database_specific,omitempty"`
+	// Internal contains information internal only to govulncheck that is
+	// not present in the OSV specification.
+	Internal Internal
 }
 
 // Credit represents a credit for the discovery, confirmation, patch, or
@@ -237,4 +240,13 @@ type DatabaseSpecific struct {
 	URL string `json:"url,omitempty"`
 	// The review status of this report (UNREVIEWED or REVIEWED).
 	ReviewStatus ReviewStatus `json:"review_status,omitempty"`
+}
+
+// Internal contains information internal and specific only to govulncheck that
+// is not present in the OSV specification.
+type Internal struct {
+	// The affected path (package import) for the OpenVEX products field.
+	AffectedPath string
+	// The affected version for the OpenVEX products field.
+	AffectedVersion string
 }

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -25,7 +25,7 @@ func addSemverPrefix(s string) string {
 
 // removeSemverPrefix removes the 'v' or 'go' prefixes from go-style
 // SEMVER strings, for usage in the public vulnerability format.
-func removeSemverPrefix(s string) string {
+func RemoveSemverPrefix(s string) string {
 	s = strings.TrimPrefix(s, "v")
 	s = strings.TrimPrefix(s, "go")
 	return s
@@ -36,7 +36,7 @@ func removeSemverPrefix(s string) string {
 // Input may be a bare SEMVER ("1.2.3"), Go prefixed SEMVER ("go1.2.3"),
 // or already canonical SEMVER ("v1.2.3").
 func canonicalizeSemverPrefix(s string) string {
-	return addSemverPrefix(removeSemverPrefix(s))
+	return addSemverPrefix(RemoveSemverPrefix(s))
 }
 
 // Less returns whether v1 < v2, where v1 and v2 are

--- a/internal/vulncheck/emit.go
+++ b/internal/vulncheck/emit.go
@@ -18,6 +18,14 @@ import (
 func emitOSVs(handler govulncheck.Handler, modVulns []*ModVulns) error {
 	for _, mv := range modVulns {
 		for _, v := range mv.Vulns {
+			// Retrieve the affected path (package) and version for
+			// the OpenVEX document.
+			v.Internal.AffectedPath = mv.Module.Path
+			v.Internal.AffectedVersion = mv.Module.Version
+			if mv.Module.Replace != nil {
+				v.Internal.AffectedPath = mv.Module.Replace.Path
+				v.Internal.AffectedVersion = mv.Module.Replace.Version
+			}
 			if err := handler.OSV(v); err != nil {
 				return err
 			}


### PR DESCRIPTION
govulncheck currently doesn't include the affected product in the OpenVEX report. Instead, it always include `Unknown Product`. Due to this, if the report is passed to Trivy as `trivy repo --vex vex-report.json ...`, no false positives will be removed, because Trivy cannot match the non affected package/version to the govulncheck report. The same also happens if Grype is used.

This implementation is certainly not perfect, but can be used as a starting point to make the generated OpenVEX report useful on an automated manner with vulnerability scanners.

When generating the `purl` identifier for the Go package, the `v` in front of the version number is removed to match what is currently supported by the Purl spec. See the upstream Purl spec issues for more information about this on going discussion https://github.com/package-url/purl-spec/issues/294 and https://github.com/package-url/purl-spec/issues/63.

Note: this is my first contribution to a Google/Go project and perhaps the code style isn't matching the expectations, so any feedback is appreciated.

Fixes https://github.com/golang/go/issues/68152